### PR TITLE
Pin ubuntu image to 18.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
     parameters: # see template file for a definition of the parameters.
       stage_name: ci_build
       test_pool_definition:
-        vmImage: 'ubuntu-latest'
+        vmImage: 'ubuntu-18.04'
       e2e_pool_definition:
         vmImage: 'ubuntu-16.04'
       environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"


### PR DESCRIPTION
Azure pipelines recently updated the latest ubuntu OS to 20.04, which I think caused CI to fail for the 1.11 branch. Pinning the ubuntu OS to 18.04 seems to fix whatever was going wrong