### PR TITLE
cherrypick commits for FLINK-10052

### DIFF
--- a/docs/content.zh/docs/deployment/ha/zookeeper_ha.md
+++ b/docs/content.zh/docs/deployment/ha/zookeeper_ha.md
@@ -105,6 +105,19 @@ You can also find further details on [how Flink sets up Kerberos-based security 
 
 {{< top >}}
 
+## Advanced Configuration
+
+### Tolerating Suspended ZooKeeper Connections
+
+Per default, Flink's ZooKeeper client treats suspended ZooKeeper connections as an error.
+This means that Flink will invalidate all leaderships of its components and thereby triggering a failover if a connection is suspended.
+
+This behaviour might be too disruptive in some cases (e.g., unstable network environment).
+If you are willing to take a more aggressive approach, then you can tolerate suspended ZooKeeper connections and only treat lost connections as an error via [high-availability.zookeeper.client.tolerate-suspended-connections]({{< ref "docs/deployment/config" >}}#high-availability-zookeeper-client-tolerate-suspended-connection).
+Enabling this feature will make Flink more resilient against temporary connection problems but also increase the risk of running into ZooKeeper timing problems.
+
+For more information take a look at [Curator's error handling](https://curator.apache.org/errors.html).
+
 ## ZooKeeper Versions
 
 Flink ships with separate ZooKeeper clients for 3.4 and 3.5, with 3.4 being in the `lib` directory of the distribution

--- a/docs/content/docs/deployment/ha/zookeeper_ha.md
+++ b/docs/content/docs/deployment/ha/zookeeper_ha.md
@@ -105,6 +105,19 @@ You can also find further details on [how Flink sets up Kerberos-based security 
 
 {{< top >}}
 
+## Advanced Configuration
+
+### Tolerating Suspended ZooKeeper Connections
+
+Per default, Flink's ZooKeeper client treats suspended ZooKeeper connections as an error.
+This means that Flink will invalidate all leaderships of its components and thereby triggering a failover if a connection is suspended.
+
+This behaviour might be too disruptive in some cases (e.g., unstable network environment).
+If you are willing to take a more aggressive approach, then you can tolerate suspended ZooKeeper connections and only treat lost connections as an error via [high-availability.zookeeper.client.tolerate-suspended-connections]({{< ref "docs/deployment/config" >}}#high-availability-zookeeper-client-tolerate-suspended-connection).
+Enabling this feature will make Flink more resilient against temporary connection problems but also increase the risk of running into ZooKeeper timing problems.
+
+For more information take a look at [Curator's error handling](https://curator.apache.org/errors.html).
+
 ## ZooKeeper Versions
 
 Flink ships with separate ZooKeeper clients for 3.4 and 3.5, with 3.4 being in the `lib` directory of the distribution

--- a/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
+++ b/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
@@ -39,6 +39,12 @@
             <td>Defines the session timeout for the ZooKeeper session in ms.</td>
         </tr>
         <tr>
+            <td><h5>high-availability.zookeeper.client.tolerate-suspended-connections</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Defines whether a suspended ZooKeeper connection will be treated as an error that causes the leader information to be invalidated or not. In case you set this option to <code class="highlighter-rouge">true</code>, Flink will wait until a ZooKeeper connection is marked as lost before it revokes the leadership of components. This has the effect that Flink is more resilient against temporary connection instabilities at the cost of running more likely into timing issues with ZooKeeper.</td>
+        </tr>
+        <tr>
             <td><h5>high-availability.zookeeper.path.checkpoint-counter</h5></td>
             <td style="word-wrap: break-word;">"/checkpoint-counter"</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/high_availability_configuration.html
+++ b/docs/layouts/shortcodes/generated/high_availability_configuration.html
@@ -75,6 +75,12 @@
             <td>ZooKeeper root path (ZNode) for completed checkpoints.</td>
         </tr>
         <tr>
+            <td><h5>high-availability.zookeeper.client.tolerate-suspended-connections</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Defines whether a suspended ZooKeeper connection will be treated as an error that causes the leader information to be invalidated or not. In case you set this option to <code class="highlighter-rouge">true</code>, Flink will wait until a ZooKeeper connection is marked as lost before it revokes the leadership of components. This has the effect that Flink is more resilient against temporary connection instabilities at the cost of running more likely into timing issues with ZooKeeper.</td>
+        </tr>
+        <tr>
             <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
             <td style="word-wrap: break-word;">"/jobgraphs"</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -216,6 +217,22 @@ public class HighAvailabilityOptions {
                             "Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be"
                                     + " set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use"
                                     + " SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos).");
+
+    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
+    public static final ConfigOption<Boolean> ZOOKEEPER_TOLERATE_SUSPENDED_CONNECTIONS =
+            key("high-availability.zookeeper.client.tolerate-suspended-connections")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines whether a suspended ZooKeeper connection will be treated as an error that causes the leader "
+                                                    + "information to be invalidated or not. In case you set this option to %s, Flink will wait until a "
+                                                    + "ZooKeeper connection is marked as lost before it revokes the leadership of components. This has the "
+                                                    + "effect that Flink is more resilient against temporary connection instabilities at the cost of running "
+                                                    + "more likely into timing issues with ZooKeeper.",
+                                            TextElement.code("true"))
+                                    .build());
 
     // ------------------------------------------------------------------------
     //  Deprecated options

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -273,10 +273,7 @@ public class ZooKeeperLeaderElectionDriver
                 LOG.debug("Connected to ZooKeeper quorum. Leader election can start.");
                 break;
             case SUSPENDED:
-                LOG.warn(
-                        "Connection to ZooKeeper suspended. The contender "
-                                + leaderContenderDescription
-                                + " no longer participates in the leader election.");
+                LOG.warn("Connection to ZooKeeper suspended, waiting for reconnection.");
                 break;
             case RECONNECTED:
                 LOG.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalDriver.java
@@ -64,6 +64,8 @@ public class ZooKeeperLeaderRetrievalDriver
 
     private final LeaderRetrievalEventHandler leaderRetrievalEventHandler;
 
+    private final LeaderInformationClearancePolicy leaderInformationClearancePolicy;
+
     private final FatalErrorHandler fatalErrorHandler;
 
     private volatile boolean running;
@@ -74,18 +76,22 @@ public class ZooKeeperLeaderRetrievalDriver
      * @param client Client which constitutes the connection to the ZooKeeper quorum
      * @param retrievalPath Path of the ZooKeeper node which contains the leader information
      * @param leaderRetrievalEventHandler Handler to notify the leader changes.
+     * @param leaderInformationClearancePolicy leaderInformationClearancePolicy controls when the
+     *     leader information is being cleared
      * @param fatalErrorHandler Fatal error handler
      */
     public ZooKeeperLeaderRetrievalDriver(
             CuratorFramework client,
             String retrievalPath,
             LeaderRetrievalEventHandler leaderRetrievalEventHandler,
+            LeaderInformationClearancePolicy leaderInformationClearancePolicy,
             FatalErrorHandler fatalErrorHandler)
             throws Exception {
         this.client = checkNotNull(client, "CuratorFramework client");
         this.cache = new NodeCache(client, retrievalPath);
         this.retrievalPath = checkNotNull(retrievalPath);
         this.leaderRetrievalEventHandler = checkNotNull(leaderRetrievalEventHandler);
+        this.leaderInformationClearancePolicy = leaderInformationClearancePolicy;
         this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
 
         client.getUnhandledErrorListenable().addListener(this);
@@ -141,7 +147,7 @@ public class ZooKeeperLeaderRetrievalDriver
                     return;
                 }
             }
-            leaderRetrievalEventHandler.notifyLeaderAddress(LeaderInformation.empty());
+            notifyNoLeader();
         } catch (Exception e) {
             fatalErrorHandler.onFatalError(
                     new LeaderRetrievalException("Could not handle node changed event.", e));
@@ -155,10 +161,11 @@ public class ZooKeeperLeaderRetrievalDriver
                 LOG.debug("Connected to ZooKeeper quorum. Leader retrieval can start.");
                 break;
             case SUSPENDED:
-                LOG.warn(
-                        "Connection to ZooKeeper suspended. Can no longer retrieve the leader from "
-                                + "ZooKeeper.");
-                leaderRetrievalEventHandler.notifyLeaderAddress(LeaderInformation.empty());
+                LOG.warn("Connection to ZooKeeper suspended, waiting for reconnection.");
+                if (leaderInformationClearancePolicy
+                        == LeaderInformationClearancePolicy.ON_SUSPENDED_CONNECTION) {
+                    notifyNoLeader();
+                }
                 break;
             case RECONNECTED:
                 LOG.info(
@@ -169,9 +176,13 @@ public class ZooKeeperLeaderRetrievalDriver
                 LOG.warn(
                         "Connection to ZooKeeper lost. Can no longer retrieve the leader from "
                                 + "ZooKeeper.");
-                leaderRetrievalEventHandler.notifyLeaderAddress(LeaderInformation.empty());
+                notifyNoLeader();
                 break;
         }
+    }
+
+    private void notifyNoLeader() {
+        leaderRetrievalEventHandler.notifyLeaderAddress(LeaderInformation.empty());
     }
 
     private void onReconnectedConnectionState() {
@@ -189,5 +200,14 @@ public class ZooKeeperLeaderRetrievalDriver
     @Override
     public String toString() {
         return "ZookeeperLeaderRetrievalDriver{" + "retrievalPath='" + retrievalPath + '\'' + '}';
+    }
+
+    /** Policy when to clear the leader information and to notify the listener about it. */
+    public enum LeaderInformationClearancePolicy {
+        // clear the leader information as soon as the ZK connection is suspended
+        ON_SUSPENDED_CONNECTION,
+
+        // clear the leader information only once the ZK connection is lost
+        ON_LOST_CONNECTION
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalDriverFactory.java
@@ -29,9 +29,17 @@ public class ZooKeeperLeaderRetrievalDriverFactory implements LeaderRetrievalDri
 
     private final String retrievalPath;
 
-    public ZooKeeperLeaderRetrievalDriverFactory(CuratorFramework client, String retrievalPath) {
+    private final ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+            leaderInformationClearancePolicy;
+
+    public ZooKeeperLeaderRetrievalDriverFactory(
+            CuratorFramework client,
+            String retrievalPath,
+            ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                    leaderInformationClearancePolicy) {
         this.client = client;
         this.retrievalPath = retrievalPath;
+        this.leaderInformationClearancePolicy = leaderInformationClearancePolicy;
     }
 
     @Override
@@ -39,6 +47,10 @@ public class ZooKeeperLeaderRetrievalDriverFactory implements LeaderRetrievalDri
             LeaderRetrievalEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler)
             throws Exception {
         return new ZooKeeperLeaderRetrievalDriver(
-                client, retrievalPath, leaderEventHandler, fatalErrorHandler);
+                client,
+                retrievalPath,
+                leaderEventHandler,
+                leaderInformationClearancePolicy,
+                fatalErrorHandler);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -487,38 +487,24 @@ public class ZooKeeperUtils {
                 prefix);
     }
 
-    /** Creates a ZooKeeper path of the form "/root/child". */
-    public static String generateZookeeperPath(String root, String child) {
-        final String result =
-                Stream.of(root, child)
-                        .map(ZooKeeperUtils::trimSlashes)
-                        .filter(s -> !s.isEmpty())
-                        .collect(Collectors.joining("/", "/", ""));
+    public static String generateZookeeperPath(String root, String namespace) {
+        if (!namespace.startsWith("/")) {
+            namespace = '/' + namespace;
+        }
 
-        return result;
+        if (namespace.endsWith("/")) {
+            namespace = namespace.substring(0, namespace.length() - 1);
+        }
+
+        if (root.endsWith("/")) {
+            root = root.substring(0, root.length() - 1);
+        }
+
+        return root + namespace;
     }
 
     public static String trimStartingSlash(String path) {
         return path.startsWith("/") ? path.substring(1) : path;
-    }
-
-    private static String trimSlashes(String input) {
-        int left = 0;
-        int right = input.length() - 1;
-
-        while (left <= right && input.charAt(left) == '/') {
-            left++;
-        }
-
-        while (right >= left && input.charAt(right) == '/') {
-            right--;
-        }
-
-        if (left <= right) {
-            return input.substring(left, right + 1);
-        } else {
-            return "";
-        }
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -67,8 +67,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -18,310 +18,231 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalEventHandler;
-import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver;
-import org.apache.flink.runtime.rpc.DirectlyFailingFatalErrorHandler;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
-import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.BiConsumerWithException;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionState;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionStateListener;
 
-import org.apache.curator.test.TestingServer;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
 
-/** Tests for the error handling in case of a suspended connection to the ZooKeeper instance. */
+/**
+ * Test behaviors of {@link ZooKeeperLeaderElectionDriver} when losing the connection to ZooKeeper.
+ */
 public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
-    private TestingServer testingServer;
+    private static final String PATH = "/path";
 
-    private Configuration config;
+    @Rule public final ZooKeeperResource zooKeeperResource = new ZooKeeperResource();
 
-    private CuratorFramework zooKeeperClient;
+    @Rule
+    public final TestingFatalErrorHandlerResource fatalErrorHandlerResource =
+            new TestingFatalErrorHandlerResource();
 
-    private final FatalErrorHandler fatalErrorHandler = DirectlyFailingFatalErrorHandler.INSTANCE;
+    private final Configuration configuration = new Configuration();
 
     @Before
-    public void before() throws Exception {
-        testingServer = new TestingServer();
-
-        config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        config.setString(
-                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
-
-        zooKeeperClient = ZooKeeperUtils.startCuratorFramework(config);
-    }
-
-    @After
-    public void after() throws Exception {
-        closeTestServer();
-
-        if (zooKeeperClient != null) {
-            zooKeeperClient.close();
-            zooKeeperClient = null;
-        }
+    public void setup() {
+        configuration.set(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
     }
 
     @Test
-    public void testConnectionSuspendedHandlingDuringInitialization() throws Exception {
-        final QueueLeaderElectionListener queueLeaderElectionListener =
-                new QueueLeaderElectionListener(1);
-
-        LeaderRetrievalDriver leaderRetrievalDriver = null;
-        try {
-            leaderRetrievalDriver =
-                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(zooKeeperClient, config)
-                            .createLeaderRetrievalDriver(
-                                    queueLeaderElectionListener, fatalErrorHandler);
-
-            // do the testing
-            final CompletableFuture<String> firstAddress =
-                    queueLeaderElectionListener.next(Duration.ofMillis(50));
-            assertThat(
-                    "No results are expected, yet, since no leader was elected.",
-                    firstAddress,
-                    is(nullValue()));
-
-            closeTestServer();
-
-            // QueueLeaderElectionListener will be notified with an empty leader when ZK connection
-            // is suspended
-            final CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
-            assertThat("The next result must not be missing.", secondAddress, is(notNullValue()));
-            assertThat(
-                    "The next result is expected to be null.",
-                    secondAddress.get(),
-                    is(nullValue()));
-        } finally {
-            if (leaderRetrievalDriver != null) {
-                leaderRetrievalDriver.close();
-            }
-        }
+    public void testLoseLeadershipOnConnectionSuspended() throws Exception {
+        runTestWithBrieflySuspendedZooKeeperConnection(
+                configuration,
+                (connectionStateListener, contender) -> {
+                    connectionStateListener.awaitSuspendedConnection();
+                    contender.awaitRevokeLeadership(Duration.ofSeconds(1L));
+                });
     }
 
     @Test
-    public void testConnectionSuspendedHandling() throws Exception {
-        final String retrievalPath = "/testConnectionSuspendedHandling/leaderAddress";
-        final String leaderAddress = "localhost";
-
-        final QueueLeaderElectionListener queueLeaderElectionListener =
-                new QueueLeaderElectionListener(1);
-        LeaderRetrievalDriver leaderRetrievalDriver = null;
-        try {
-            leaderRetrievalDriver =
-                    new ZooKeeperLeaderRetrievalDriver(
-                            zooKeeperClient,
-                            retrievalPath,
-                            queueLeaderElectionListener,
-                            fatalErrorHandler);
-
-            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, UUID.randomUUID());
-
-            // do the testing
-            CompletableFuture<String> firstAddress = queueLeaderElectionListener.next();
-            assertThat(
-                    "The first result is expected to be the initially set leader address.",
-                    firstAddress.get(),
-                    is(leaderAddress));
-
-            closeTestServer();
-
-            CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
-            assertThat("The next result must not be missing.", secondAddress, is(notNullValue()));
-            assertThat(
-                    "The next result is expected to be null.",
-                    secondAddress.get(),
-                    is(nullValue()));
-        } finally {
-            if (leaderRetrievalDriver != null) {
-                leaderRetrievalDriver.close();
-            }
-        }
+    public void testKeepLeadershipOnSuspendedConnectionIfTolerateSuspendedConnectionsIsEnabled()
+            throws Exception {
+        configuration.set(HighAvailabilityOptions.ZOOKEEPER_TOLERATE_SUSPENDED_CONNECTIONS, true);
+        runTestWithBrieflySuspendedZooKeeperConnection(
+                configuration,
+                (connectionStateListener, contender) -> {
+                    connectionStateListener.awaitSuspendedConnection();
+                    connectionStateListener.awaitReconnectedConnection();
+                    assertFalse(contender.hasRevokeLeadershipBeenTriggered());
+                });
     }
 
     @Test
-    public void testSameLeaderAfterReconnectTriggersListenerNotification() throws Exception {
-        final String retrievalPath =
-                "/testSameLeaderAfterReconnectTriggersListenerNotification/leaderAddress";
-        final QueueLeaderElectionListener queueLeaderElectionListener =
-                new QueueLeaderElectionListener(1);
-        LeaderRetrievalDriver leaderRetrievalDriver = null;
+    public void testLoseLeadershipOnLostConnectionIfTolerateSuspendedConnectionsIsEnabled()
+            throws Exception {
+        configuration.set(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, 1000);
+        configuration.set(HighAvailabilityOptions.ZOOKEEPER_CONNECTION_TIMEOUT, 1000);
+        configuration.set(HighAvailabilityOptions.ZOOKEEPER_TOLERATE_SUSPENDED_CONNECTIONS, true);
+        runTestWithLostZooKeeperConnection(
+                configuration,
+                (connectionStateListener, contender) -> {
+                    connectionStateListener.awaitLostConnection();
+                    contender.awaitRevokeLeadership(Duration.ofSeconds(1L));
+                });
+    }
+
+    private void runTestWithLostZooKeeperConnection(
+            Configuration configuration,
+            BiConsumerWithException<TestingConnectionStateListener, TestingContender, Exception>
+                    validationLogic)
+            throws Exception {
+        runTestWithZooKeeperConnectionProblem(
+                configuration, validationLogic, Problem.LOST_CONNECTION);
+    }
+
+    private void runTestWithBrieflySuspendedZooKeeperConnection(
+            Configuration configuration,
+            BiConsumerWithException<TestingConnectionStateListener, TestingContender, Exception>
+                    validationLogic)
+            throws Exception {
+        runTestWithZooKeeperConnectionProblem(
+                configuration, validationLogic, Problem.SUSPENDED_CONNECTION);
+    }
+
+    private enum Problem {
+        LOST_CONNECTION,
+        SUSPENDED_CONNECTION
+    }
+
+    private void runTestWithZooKeeperConnectionProblem(
+            Configuration configuration,
+            BiConsumerWithException<TestingConnectionStateListener, TestingContender, Exception>
+                    validationLogic,
+            Problem problem)
+            throws Exception {
+        CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        LeaderElectionDriverFactory leaderElectionDriverFactory =
+                new ZooKeeperLeaderElectionDriverFactory(
+                        client,
+                        PATH,
+                        configuration.getString(HighAvailabilityOptions.HA_ZOOKEEPER_LEADER_PATH));
+        DefaultLeaderElectionService leaderElectionService =
+                new DefaultLeaderElectionService(leaderElectionDriverFactory);
+
         try {
-            leaderRetrievalDriver =
-                    new ZooKeeperLeaderRetrievalDriver(
-                            zooKeeperClient,
-                            retrievalPath,
-                            queueLeaderElectionListener,
-                            fatalErrorHandler);
+            final TestingConnectionStateListener connectionStateListener =
+                    new TestingConnectionStateListener();
+            client.getConnectionStateListenable().addListener(connectionStateListener);
 
-            final String leaderAddress = "foobar";
-            final UUID sessionId = UUID.randomUUID();
-            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, sessionId);
+            final TestingContender contender = new TestingContender();
+            leaderElectionService.start(contender);
 
-            // pop new leader
-            queueLeaderElectionListener.next();
+            contender.awaitGrantLeadership();
 
-            testingServer.stop();
-
-            final CompletableFuture<String> connectionSuspension =
-                    queueLeaderElectionListener.next();
-
-            // wait until the ZK connection is suspended
-            connectionSuspension.join();
-
-            testingServer.restart();
-
-            // new old leader information should be announced
-            final CompletableFuture<String> connectionReconnect =
-                    queueLeaderElectionListener.next();
-            assertThat(connectionReconnect.get(), is(leaderAddress));
-        } finally {
-            if (leaderRetrievalDriver != null) {
-                leaderRetrievalDriver.close();
+            switch (problem) {
+                case SUSPENDED_CONNECTION:
+                    zooKeeperResource.restart();
+                    break;
+                case LOST_CONNECTION:
+                    zooKeeperResource.stop();
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            String.format("Unknown problem type %s.", problem));
             }
-        }
-    }
 
-    private void writeLeaderInformationToZooKeeper(
-            String retrievalPath, String leaderAddress, UUID sessionId) throws Exception {
-        final byte[] data = createLeaderInformation(leaderAddress, sessionId);
-        if (zooKeeperClient.checkExists().forPath(retrievalPath) != null) {
-            zooKeeperClient.setData().forPath(retrievalPath, data);
-        } else {
-            zooKeeperClient.create().creatingParentsIfNeeded().forPath(retrievalPath, data);
-        }
-    }
-
-    private byte[] createLeaderInformation(String leaderAddress, UUID sessionId)
-            throws IOException {
-        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                final ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-
-            oos.writeUTF(leaderAddress);
-            oos.writeObject(sessionId);
-
-            oos.flush();
-
-            return baos.toByteArray();
-        }
-    }
-
-    @Test
-    public void testNewLeaderAfterReconnectTriggersListenerNotification() throws Exception {
-        final String retrievalPath =
-                "/testNewLeaderAfterReconnectTriggersListenerNotification/leaderAddress";
-        final QueueLeaderElectionListener queueLeaderElectionListener =
-                new QueueLeaderElectionListener(1);
-
-        LeaderRetrievalDriver leaderRetrievalDriver = null;
-        try {
-            leaderRetrievalDriver =
-                    new ZooKeeperLeaderRetrievalDriver(
-                            zooKeeperClient,
-                            retrievalPath,
-                            queueLeaderElectionListener,
-                            fatalErrorHandler);
-
-            final String leaderAddress = "foobar";
-            final UUID sessionId = UUID.randomUUID();
-            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, sessionId);
-
-            // pop new leader
-            queueLeaderElectionListener.next();
-
-            testingServer.stop();
-
-            final CompletableFuture<String> connectionSuspension =
-                    queueLeaderElectionListener.next();
-
-            // wait until the ZK connection is suspended
-            connectionSuspension.join();
-
-            testingServer.restart();
-
-            final String newLeaderAddress = "barfoo";
-            final UUID newSessionId = UUID.randomUUID();
-            writeLeaderInformationToZooKeeper(retrievalPath, newLeaderAddress, newSessionId);
-
-            // check that we find the new leader information eventually
-            CommonTestUtils.waitUntilCondition(
-                    () -> {
-                        final CompletableFuture<String> afterConnectionReconnect =
-                                queueLeaderElectionListener.next();
-                        return afterConnectionReconnect.get().equals(newLeaderAddress);
-                    },
-                    Deadline.fromNow(Duration.ofSeconds(30L)));
+            validationLogic.accept(connectionStateListener, contender);
         } finally {
-            if (leaderRetrievalDriver != null) {
-                leaderRetrievalDriver.close();
-            }
+            leaderElectionService.stop();
+            client.close();
         }
     }
 
-    private void closeTestServer() throws IOException {
-        if (testingServer != null) {
-            testingServer.close();
-            testingServer = null;
-        }
-    }
+    private final class TestingContender implements LeaderContender {
 
-    private static class QueueLeaderElectionListener implements LeaderRetrievalEventHandler {
+        private final OneShotLatch grantLeadershipLatch;
+        private final OneShotLatch revokeLeadershipLatch;
 
-        private final BlockingQueue<CompletableFuture<String>> queue;
-
-        public QueueLeaderElectionListener(int expectedCalls) {
-            this.queue = new ArrayBlockingQueue<>(expectedCalls);
+        private TestingContender() {
+            this.grantLeadershipLatch = new OneShotLatch();
+            this.revokeLeadershipLatch = new OneShotLatch();
         }
 
         @Override
-        public void notifyLeaderAddress(LeaderInformation leaderInformation) {
-            final String leaderAddress = leaderInformation.getLeaderAddress();
-            try {
-                queue.put(CompletableFuture.completedFuture(leaderAddress));
-            } catch (InterruptedException e) {
-                throw new IllegalStateException(e);
+        public void grantLeadership(UUID leaderSessionID) {
+            grantLeadershipLatch.trigger();
+        }
+
+        @Override
+        public void revokeLeadership() {
+            revokeLeadershipLatch.trigger();
+        }
+
+        @Override
+        public void handleError(Exception exception) {
+            fatalErrorHandlerResource.getFatalErrorHandler().onFatalError(exception);
+        }
+
+        public void awaitGrantLeadership() throws InterruptedException {
+            grantLeadershipLatch.await();
+        }
+
+        public boolean hasRevokeLeadershipBeenTriggered() {
+            return revokeLeadershipLatch.isTriggered();
+        }
+
+        public void awaitRevokeLeadership(Duration timeout)
+                throws InterruptedException, TimeoutException {
+            revokeLeadershipLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private static final class TestingConnectionStateListener implements ConnectionStateListener {
+        private final OneShotLatch connectionSuspendedLatch;
+        private final OneShotLatch reconnectedLatch;
+        private final OneShotLatch connectionLostLatch;
+
+        public TestingConnectionStateListener() {
+            this.connectionSuspendedLatch = new OneShotLatch();
+            this.reconnectedLatch = new OneShotLatch();
+            this.connectionLostLatch = new OneShotLatch();
+        }
+
+        @Override
+        public void stateChanged(
+                CuratorFramework curatorFramework, ConnectionState connectionState) {
+            if (connectionState == ConnectionState.SUSPENDED) {
+                connectionSuspendedLatch.trigger();
+            }
+
+            if (connectionState == ConnectionState.RECONNECTED) {
+                reconnectedLatch.trigger();
+            }
+
+            if (connectionState == ConnectionState.LOST) {
+                connectionLostLatch.trigger();
             }
         }
 
-        public CompletableFuture<String> next() {
-            return next(null);
+        public void awaitSuspendedConnection() throws InterruptedException {
+            connectionSuspendedLatch.await();
         }
 
-        public CompletableFuture<String> next(@Nullable Duration timeout) {
-            try {
-                if (timeout == null) {
-                    return queue.take();
-                } else {
-                    return this.queue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
-                }
-            } catch (InterruptedException e) {
-                throw new IllegalStateException(e);
-            }
+        public void awaitReconnectedConnection() throws InterruptedException {
+            reconnectedLatch.await();
+        }
+
+        public void awaitLostConnection() throws InterruptedException {
+            connectionLostLatch.await();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalEventHandler;
+import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the error handling in case of a suspended connection to the ZooKeeper instance when
+ * retrieving the leader information.
+ */
+public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
+
+    private TestingServer testingServer;
+
+    private Configuration config;
+
+    private CuratorFramework zooKeeperClient;
+
+    @Rule
+    public final TestingFatalErrorHandlerResource fatalErrorHandlerResource =
+            new TestingFatalErrorHandlerResource();
+
+    @Before
+    public void before() throws Exception {
+        testingServer = new TestingServer();
+
+        config = new Configuration();
+        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config.setString(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
+
+        zooKeeperClient = ZooKeeperUtils.startCuratorFramework(config);
+        zooKeeperClient.blockUntilConnected();
+    }
+
+    @After
+    public void after() throws Exception {
+        closeTestServer();
+
+        if (zooKeeperClient != null) {
+            zooKeeperClient.close();
+            zooKeeperClient = null;
+        }
+    }
+
+    @Test
+    public void testConnectionSuspendedHandlingDuringInitialization() throws Exception {
+        final QueueLeaderElectionListener queueLeaderElectionListener =
+                new QueueLeaderElectionListener(1);
+
+        LeaderRetrievalDriver leaderRetrievalDriver = null;
+        try {
+            leaderRetrievalDriver =
+                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(zooKeeperClient, config)
+                            .createLeaderRetrievalDriver(
+                                    queueLeaderElectionListener,
+                                    fatalErrorHandlerResource.getFatalErrorHandler());
+
+            // do the testing
+            final CompletableFuture<String> firstAddress =
+                    queueLeaderElectionListener.next(Duration.ofMillis(50));
+            assertThat(
+                    "No results are expected, yet, since no leader was elected.",
+                    firstAddress,
+                    is(nullValue()));
+
+            closeTestServer();
+
+            // QueueLeaderElectionListener will be notified with an empty leader when ZK connection
+            // is suspended
+            final CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
+            assertThat("The next result must not be missing.", secondAddress, is(notNullValue()));
+            assertThat(
+                    "The next result is expected to be null.",
+                    secondAddress.get(),
+                    is(nullValue()));
+        } finally {
+            if (leaderRetrievalDriver != null) {
+                leaderRetrievalDriver.close();
+            }
+        }
+    }
+
+    @Test
+    public void testConnectionSuspendedHandling() throws Exception {
+        final String retrievalPath = "/testConnectionSuspendedHandling";
+        final String leaderAddress = "localhost";
+
+        final QueueLeaderElectionListener queueLeaderElectionListener =
+                new QueueLeaderElectionListener(1);
+        ZooKeeperLeaderRetrievalDriver leaderRetrievalDriver = null;
+        try {
+            leaderRetrievalDriver =
+                    new ZooKeeperLeaderRetrievalDriver(
+                            zooKeeperClient,
+                            retrievalPath,
+                            queueLeaderElectionListener,
+                            ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                                    .ON_SUSPENDED_CONNECTION,
+                            fatalErrorHandlerResource.getFatalErrorHandler());
+
+            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, UUID.randomUUID());
+
+            // do the testing
+            CompletableFuture<String> firstAddress = queueLeaderElectionListener.next();
+            assertThat(
+                    "The first result is expected to be the initially set leader address.",
+                    firstAddress.get(),
+                    is(leaderAddress));
+
+            closeTestServer();
+
+            CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
+            assertThat("The next result must not be missing.", secondAddress, is(notNullValue()));
+            assertThat(
+                    "The next result is expected to be null.",
+                    secondAddress.get(),
+                    is(nullValue()));
+        } finally {
+            if (leaderRetrievalDriver != null) {
+                leaderRetrievalDriver.close();
+            }
+        }
+    }
+
+    @Test
+    public void testSuspendedConnectionDoesNotClearLeaderInformationIfClearanceOnLostConnection()
+            throws Exception {
+        final String retrievalPath = "/testConnectionSuspendedHandling";
+        final String leaderAddress = "localhost";
+
+        final QueueLeaderElectionListener queueLeaderElectionListener =
+                new QueueLeaderElectionListener(1);
+        ZooKeeperLeaderRetrievalDriver leaderRetrievalDriver = null;
+        try {
+            leaderRetrievalDriver =
+                    new ZooKeeperLeaderRetrievalDriver(
+                            zooKeeperClient,
+                            retrievalPath,
+                            queueLeaderElectionListener,
+                            ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                                    .ON_LOST_CONNECTION,
+                            fatalErrorHandlerResource.getFatalErrorHandler());
+
+            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, UUID.randomUUID());
+
+            // do the testing
+            CompletableFuture<String> firstAddress = queueLeaderElectionListener.next();
+            assertThat(
+                    "The first result is expected to be the initially set leader address.",
+                    firstAddress.get(),
+                    is(leaderAddress));
+
+            closeTestServer();
+
+            // make sure that no new leader information is published
+            assertThat(queueLeaderElectionListener.next(Duration.ofMillis(100L)), is(nullValue()));
+        } finally {
+            if (leaderRetrievalDriver != null) {
+                leaderRetrievalDriver.close();
+            }
+        }
+    }
+
+    @Test
+    public void testSameLeaderAfterReconnectTriggersListenerNotification() throws Exception {
+        final String retrievalPath = "/testSameLeaderAfterReconnectTriggersListenerNotification";
+        final QueueLeaderElectionListener queueLeaderElectionListener =
+                new QueueLeaderElectionListener(1);
+        ZooKeeperLeaderRetrievalDriver leaderRetrievalDriver = null;
+        try {
+            leaderRetrievalDriver =
+                    new ZooKeeperLeaderRetrievalDriver(
+                            zooKeeperClient,
+                            retrievalPath,
+                            queueLeaderElectionListener,
+                            ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                                    .ON_SUSPENDED_CONNECTION,
+                            fatalErrorHandlerResource.getFatalErrorHandler());
+
+            final String leaderAddress = "foobar";
+            final UUID sessionId = UUID.randomUUID();
+            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, sessionId);
+
+            // pop new leader
+            queueLeaderElectionListener.next();
+
+            testingServer.stop();
+
+            final CompletableFuture<String> connectionSuspension =
+                    queueLeaderElectionListener.next();
+
+            // wait until the ZK connection is suspended
+            connectionSuspension.join();
+
+            testingServer.restart();
+
+            // new old leader information should be announced
+            final CompletableFuture<String> connectionReconnect =
+                    queueLeaderElectionListener.next();
+            assertThat(connectionReconnect.get(), is(leaderAddress));
+        } finally {
+            if (leaderRetrievalDriver != null) {
+                leaderRetrievalDriver.close();
+            }
+        }
+    }
+
+    private void writeLeaderInformationToZooKeeper(
+            String retrievalPath, String leaderAddress, UUID sessionId) throws Exception {
+        final byte[] data = createLeaderInformation(leaderAddress, sessionId);
+        if (zooKeeperClient.checkExists().forPath(retrievalPath) != null) {
+            zooKeeperClient.setData().forPath(retrievalPath, data);
+        } else {
+            zooKeeperClient.create().creatingParentsIfNeeded().forPath(retrievalPath, data);
+        }
+    }
+
+    private byte[] createLeaderInformation(String leaderAddress, UUID sessionId)
+            throws IOException {
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+
+            oos.writeUTF(leaderAddress);
+            oos.writeObject(sessionId);
+
+            oos.flush();
+
+            return baos.toByteArray();
+        }
+    }
+
+    @Test
+    public void testNewLeaderAfterReconnectTriggersListenerNotification() throws Exception {
+        final String retrievalPath = "/testNewLeaderAfterReconnectTriggersListenerNotification";
+        final QueueLeaderElectionListener queueLeaderElectionListener =
+                new QueueLeaderElectionListener(1);
+
+        ZooKeeperLeaderRetrievalDriver leaderRetrievalDriver = null;
+        try {
+            leaderRetrievalDriver =
+                    new ZooKeeperLeaderRetrievalDriver(
+                            zooKeeperClient,
+                            retrievalPath,
+                            queueLeaderElectionListener,
+                            ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                                    .ON_SUSPENDED_CONNECTION,
+                            fatalErrorHandlerResource.getFatalErrorHandler());
+
+            final String leaderAddress = "foobar";
+            final UUID sessionId = UUID.randomUUID();
+            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, sessionId);
+
+            // pop new leader
+            queueLeaderElectionListener.next();
+
+            testingServer.stop();
+
+            final CompletableFuture<String> connectionSuspension =
+                    queueLeaderElectionListener.next();
+
+            // wait until the ZK connection is suspended
+            connectionSuspension.join();
+
+            testingServer.restart();
+
+            final String newLeaderAddress = "barfoo";
+            final UUID newSessionId = UUID.randomUUID();
+            writeLeaderInformationToZooKeeper(retrievalPath, newLeaderAddress, newSessionId);
+
+            // check that we find the new leader information eventually
+            CommonTestUtils.waitUntilCondition(
+                    () -> {
+                        final CompletableFuture<String> afterConnectionReconnect =
+                                queueLeaderElectionListener.next();
+                        return afterConnectionReconnect.get().equals(newLeaderAddress);
+                    },
+                    Deadline.fromNow(Duration.ofSeconds(30L)));
+        } finally {
+            if (leaderRetrievalDriver != null) {
+                leaderRetrievalDriver.close();
+            }
+        }
+    }
+
+    private void closeTestServer() throws IOException {
+        if (testingServer != null) {
+            testingServer.close();
+            testingServer = null;
+        }
+    }
+
+    private static class QueueLeaderElectionListener implements LeaderRetrievalEventHandler {
+
+        private final BlockingQueue<CompletableFuture<String>> queue;
+
+        public QueueLeaderElectionListener(int expectedCalls) {
+            this.queue = new ArrayBlockingQueue<>(expectedCalls);
+        }
+
+        @Override
+        public void notifyLeaderAddress(LeaderInformation leaderInformation) {
+            final String leaderAddress = leaderInformation.getLeaderAddress();
+            try {
+                queue.put(CompletableFuture.completedFuture(leaderAddress));
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        public CompletableFuture<String> next() {
+            return Preconditions.checkNotNull(next(null));
+        }
+
+        @Nullable
+        public CompletableFuture<String> next(@Nullable Duration timeout) {
+            try {
+                if (timeout == null) {
+                    return queue.take();
+                } else {
+                    return this.queue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+                }
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
@@ -71,4 +71,9 @@ public class ZooKeeperResource extends ExternalResource {
         Preconditions.checkNotNull(zooKeeperServer);
         zooKeeperServer.restart();
     }
+
+    public void stop() throws IOException {
+        Preconditions.checkNotNull(zooKeeperServer);
+        zooKeeperServer.stop();
+    }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Changes include cherrypicking commits responsible for FLINK-10052

d18eb5ca3caa063656ea26b2e992f7569a2bc002
82b4c24c0e98e103af8ef039c64f2bedba330e8b
9635083dbd6c998a5c6dff15cc0abf968aaea378

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
