### PR TITLE
Allow custom Kryo serializers to be registered for restored KryoSerializers

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -166,6 +166,10 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
     private LinkedHashMap<Class<?>, Class<? extends Serializer<?>>>
             registeredTypesWithKryoSerializerClasses = new LinkedHashMap<>();
 
+    // Ephemeral version of the registered types above, which does not creep into savepoints
+    // If you depend on a serializer here, you must add it every time.
+    private LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> ephemeralRegisteredTypesWithKryoSerializerClasses = new LinkedHashMap<>();
+
     private LinkedHashMap<Class<?>, SerializableSerializer<?>> defaultKryoSerializers =
             new LinkedHashMap<>();
 
@@ -780,6 +784,24 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
     }
 
     /**
+     * Registers the given Serializer via its class as a serializer for the given type at the KryoSerializer.
+     * DOES NOT PERSIST THE SERIALIZER IN SAVEPOINTS
+     *
+     * @param type The class of the types serialized with the given serializer.
+     * @param serializerClass The class of the serializer to use.
+     */
+    @SuppressWarnings("rawtypes")
+    public void registerTypeWithEphemeralKryoSerializer(Class<?> type, Class<? extends Serializer> serializerClass) {
+        if (type == null || serializerClass == null) {
+            throw new NullPointerException("Cannot register null class or serializer.");
+        }
+
+        @SuppressWarnings("unchecked")
+        Class<? extends Serializer<?>> castedSerializerClass = (Class<? extends Serializer<?>>) serializerClass;
+        ephemeralRegisteredTypesWithKryoSerializerClasses.put(type, castedSerializerClass);
+    }
+
+    /**
      * Registers the given type with the serialization stack. If the type is eventually serialized
      * as a POJO, then the type is registered with the POJO serializer. If the type ends up being
      * serialized with Kryo, then it will be registered at Kryo to make sure that only tags are
@@ -815,6 +837,13 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
     public LinkedHashMap<Class<?>, SerializableSerializer<?>>
             getRegisteredTypesWithKryoSerializers() {
         return registeredTypesWithKryoSerializers;
+    }
+
+    /**
+     * Returns the registered types with their ephemeral Kryo Serializer classes.
+     */
+    public LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> getEphemeralRegisteredTypesWithKryoSerializerClasses() {
+        return ephemeralRegisteredTypesWithKryoSerializerClasses;
     }
 
     /** Returns the registered types with their Kryo Serializer classes. */

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -168,7 +168,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
     // Ephemeral version of the registered types above, which does not creep into savepoints
     // If you depend on a serializer here, you must add it every time.
-    private LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> ephemeralRegisteredTypesWithKryoSerializerClasses = new LinkedHashMap<>();
+    private LinkedHashMap<Class<?>, Class<? extends Serializer<?>>>
+            ephemeralRegisteredTypesWithKryoSerializerClasses = new LinkedHashMap<>();
 
     private LinkedHashMap<Class<?>, SerializableSerializer<?>> defaultKryoSerializers =
             new LinkedHashMap<>();
@@ -784,20 +785,22 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
     }
 
     /**
-     * Registers the given Serializer via its class as a serializer for the given type at the KryoSerializer.
-     * DOES NOT PERSIST THE SERIALIZER IN SAVEPOINTS
+     * Registers the given Serializer via its class as a serializer for the given type at the
+     * KryoSerializer. DOES NOT PERSIST THE SERIALIZER IN SAVEPOINTS
      *
      * @param type The class of the types serialized with the given serializer.
      * @param serializerClass The class of the serializer to use.
      */
     @SuppressWarnings("rawtypes")
-    public void registerTypeWithEphemeralKryoSerializer(Class<?> type, Class<? extends Serializer> serializerClass) {
+    public void registerTypeWithEphemeralKryoSerializer(
+            Class<?> type, Class<? extends Serializer> serializerClass) {
         if (type == null || serializerClass == null) {
             throw new NullPointerException("Cannot register null class or serializer.");
         }
 
         @SuppressWarnings("unchecked")
-        Class<? extends Serializer<?>> castedSerializerClass = (Class<? extends Serializer<?>>) serializerClass;
+        Class<? extends Serializer<?>> castedSerializerClass =
+                (Class<? extends Serializer<?>>) serializerClass;
         ephemeralRegisteredTypesWithKryoSerializerClasses.put(type, castedSerializerClass);
     }
 
@@ -839,10 +842,9 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
         return registeredTypesWithKryoSerializers;
     }
 
-    /**
-     * Returns the registered types with their ephemeral Kryo Serializer classes.
-     */
-    public LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> getEphemeralRegisteredTypesWithKryoSerializerClasses() {
+    /** Returns the registered types with their ephemeral Kryo Serializer classes. */
+    public LinkedHashMap<Class<?>, Class<? extends Serializer<?>>>
+            getEphemeralRegisteredTypesWithKryoSerializerClasses() {
         return ephemeralRegisteredTypesWithKryoSerializerClasses;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -90,11 +90,11 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
     /**
      * Bind the ExecutionConfig for the Task thread.
      *
-     * This is called from within the Task thread when the ExecutionConfig has been deserialized.
+     * <p>This is called from within the Task thread when the ExecutionConfig has been deserialized.
      *
-     * The registration is thread-local value. The registered ExecutionConfig is eligible for garbage
-     * collection as soon as the task thread ends. This is at the same time that any instantiated
-     * serializer also becomes eligible for garbage collection.
+     * <p>The registration is thread-local value. The registered ExecutionConfig is eligible for
+     * garbage collection as soon as the task thread ends. This is at the same time that any
+     * instantiated serializer also becomes eligible for garbage collection.
      */
     public static void registerExecutionConfigForTaskThread(ExecutionConfig executionConfig) {
         EXECUTION_CONFIG.set(executionConfig);
@@ -118,7 +118,10 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
      */
     private LinkedHashMap<String, KryoRegistration> kryoRegistrations;
 
-    /** Use a separate transient field to not break serialization and to ensure we are not snapshotting added serializers. */
+    /**
+     * Use a separate transient field to not break serialization and to ensure we are not
+     * snapshotting added serializers.
+     */
     private transient List<KryoRegistration> ephemeralKryoRegistrations;
 
     private final Class<T> type;
@@ -216,10 +219,14 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
             ExecutionConfig executionConfig = EXECUTION_CONFIG.get();
             if (executionConfig != null) {
                 ephemeralKryoRegistrations = new ArrayList<>();
-                for (Map.Entry<Class<?>, Class<? extends Serializer<?>>> entry : executionConfig.getEphemeralRegisteredTypesWithKryoSerializerClasses().entrySet()) {
+                for (Map.Entry<Class<?>, Class<? extends Serializer<?>>> entry :
+                        executionConfig
+                                .getEphemeralRegisteredTypesWithKryoSerializerClasses()
+                                .entrySet()) {
                     Class<?> typeClass = entry.getKey();
                     Class<? extends Serializer<?>> serializerClass = entry.getValue();
-                    ephemeralKryoRegistrations.add(new KryoRegistration(typeClass, serializerClass));
+                    ephemeralKryoRegistrations.add(
+                            new KryoRegistration(typeClass, serializerClass));
                 }
             }
         } catch (Exception e) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -53,8 +53,10 @@ import java.io.ObjectInputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -82,6 +84,22 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
     private static final boolean CONCURRENT_ACCESS_CHECK =
             LOG.isDebugEnabled() || KryoSerializerDebugInitHelper.setToDebug;
 
+    // The ExecutionConfig from this Task thread. Garbage-collected when the Task threads ends.
+    private static final ThreadLocal<ExecutionConfig> EXECUTION_CONFIG = new ThreadLocal<>();
+
+    /**
+     * Bind the ExecutionConfig for the Task thread.
+     *
+     * This is called from within the Task thread when the ExecutionConfig has been deserialized.
+     *
+     * The registration is thread-local value. The registered ExecutionConfig is eligible for garbage
+     * collection as soon as the task thread ends. This is at the same time that any instantiated
+     * serializer also becomes eligible for garbage collection.
+     */
+    public static void registerExecutionConfigForTaskThread(ExecutionConfig executionConfig) {
+        EXECUTION_CONFIG.set(executionConfig);
+    }
+
     static {
         configureKryoLogging();
     }
@@ -99,6 +117,9 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
      * into account registration overwrites.
      */
     private LinkedHashMap<String, KryoRegistration> kryoRegistrations;
+
+    /** Use a separate transient field to not break serialization and to ensure we are not snapshotting added serializers. */
+    private transient List<KryoRegistration> ephemeralKryoRegistrations;
 
     private final Class<T> type;
 
@@ -190,6 +211,20 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
             LinkedHashMap<Class<?>, SerializableSerializer<?>> defaultSerializers,
             LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> defaultSerializerClasses,
             LinkedHashMap<String, KryoRegistration> kryoRegistrations) {
+
+        try {
+            ExecutionConfig executionConfig = EXECUTION_CONFIG.get();
+            if (executionConfig != null) {
+                ephemeralKryoRegistrations = new ArrayList<>();
+                for (Map.Entry<Class<?>, Class<? extends Serializer<?>>> entry : executionConfig.getEphemeralRegisteredTypesWithKryoSerializerClasses().entrySet()) {
+                    Class<?> typeClass = entry.getKey();
+                    Class<? extends Serializer<?>> serializerClass = entry.getValue();
+                    ephemeralKryoRegistrations.add(new KryoRegistration(typeClass, serializerClass));
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to load custom Kryo serializer class.", e);
+        }
 
         this.type = checkNotNull(type, "Type class cannot be null.");
         this.defaultSerializerClasses =
@@ -487,6 +522,10 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
                 kryo.addDefaultSerializer(entry.getKey(), entry.getValue());
             }
 
+            if (ephemeralKryoRegistrations != null) {
+                KryoUtils.applyRegistrations(this.kryo, ephemeralKryoRegistrations);
+            }
+
             KryoUtils.applyRegistrations(this.kryo, kryoRegistrations.values());
 
             kryo.setRegistrationRequired(false);
@@ -500,6 +539,7 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 
     @Override
     public TypeSerializerSnapshot<T> snapshotConfiguration() {
+        // Do not snapshot the ephemeral kryo registrations
         return new KryoSerializerSnapshot<>(
                 type, defaultSerializers, defaultSerializerClasses, kryoRegistrations);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -263,7 +263,7 @@ public abstract class AbstractStreamOperator<OUT>
             throws Exception {
 
         // We are being called from the StreamTask thread.
-        // The ExecutionConfig is tied to the task thread which runts this operator.
+        // The ExecutionConfig is tied to the task thread which runs this operator.
         // I'm registering here instead of in StreamTask to allow lightweight test code to leverage
         // this functionality as well.
         KryoSerializer.registerExecutionConfigForTaskThread(getExecutionConfig());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
@@ -261,6 +262,11 @@ public abstract class AbstractStreamOperator<OUT>
     public final void initializeState(StreamTaskStateInitializer streamTaskStateManager)
             throws Exception {
 
+        // We are being called from the StreamTask thread.
+        // The ExecutionConfig is tied to the task thread which runts this operator.
+        // I'm registering here instead of in StreamTask to allow lightweight test code to leverage
+        // this functionality as well.
+        KryoSerializer.registerExecutionConfigForTaskThread(getExecutionConfig());
         final TypeSerializer<?> keySerializer =
                 config.getStateKeySerializer(getUserCodeClassloader());
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This is a cherrypick commit. 
```
New serializers can only be added once the state has been restored. The state
restore process relies on the old serializer to be correctly reconstructed. In
the case of Kryo, if the serializer is dynamically resolved from the class,
changing the type class will break the serialization format.
This allows to register a custom Kryo type serializer for a given type to update
the serializer and not use the default reflection based serializer for a type.
```

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
