### PR TITLE
Add MiniClusterEntryPoint

### DIFF
--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2021 Splunk, Inc. All rights reserved.
+ */
+
 package org.apache.flink.container.entrypoint;
 
 import org.apache.flink.configuration.ConfigConstants;

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
@@ -20,21 +20,20 @@ import org.apache.flink.runtime.util.SignalHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-/**
- * Entry point for a mini cluster.
- */
+/** Entry point for a mini cluster. */
 public class MiniClusterEntryPoint {
     protected static final Logger LOG = LoggerFactory.getLogger(MiniClusterEntryPoint.class);
 
     public static void main(String[] args) {
         // startup checks and logging
-        EnvironmentInformation.logEnvironmentInfo(LOG, StandaloneSessionClusterEntrypoint.class.getSimpleName(), args);
+        EnvironmentInformation.logEnvironmentInfo(
+                LOG, StandaloneSessionClusterEntrypoint.class.getSimpleName(), args);
         SignalHandler.register(LOG);
         JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
         EntrypointClusterConfiguration entrypointClusterConfiguration = null;
-        final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+        final CommandLineParser<EntrypointClusterConfiguration> commandLineParser =
+                new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
 
         try {
             entrypointClusterConfiguration = commandLineParser.parse(args);
@@ -44,20 +43,29 @@ public class MiniClusterEntryPoint {
             System.exit(1);
         }
 
-        Configuration configuration = GlobalConfiguration.loadConfiguration(entrypointClusterConfiguration.getConfigDir());
+        Configuration configuration =
+                GlobalConfiguration.loadConfiguration(
+                        entrypointClusterConfiguration.getConfigDir());
 
-        final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
-                .setConfiguration(configuration)
-                // MiniClusterConfiguration.Builder defaults to 1 TM unless configured manually
-                .setNumTaskManagers(configuration.getInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1))
-                .build();
+        final MiniClusterConfiguration miniClusterConfiguration =
+                new MiniClusterConfiguration.Builder()
+                        .setConfiguration(configuration)
+                        // MiniClusterConfiguration.Builder defaults to 1 TM unless configured
+                        // manually
+                        .setNumTaskManagers(
+                                configuration.getInteger(
+                                        ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1))
+                        .build();
 
         MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration);
 
         try {
             miniCluster.start();
         } catch (Exception e) {
-            LOG.error("Failed to start MiniCluster with configuration {}.", miniClusterConfiguration, e);
+            LOG.error(
+                    "Failed to start MiniCluster with configuration {}.",
+                    miniClusterConfiguration,
+                    e);
             System.exit(1);
         }
     }

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
@@ -1,0 +1,60 @@
+package org.apache.flink.container.entrypoint;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.runtime.entrypoint.EntrypointClusterConfiguration;
+import org.apache.flink.runtime.entrypoint.EntrypointClusterConfigurationParserFactory;
+import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.apache.flink.runtime.util.JvmShutdownSafeguard;
+import org.apache.flink.runtime.util.SignalHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Entry point for a mini cluster.
+ */
+public class MiniClusterEntryPoint {
+    protected static final Logger LOG = LoggerFactory.getLogger(MiniClusterEntryPoint.class);
+
+    public static void main(String[] args) {
+        // startup checks and logging
+        EnvironmentInformation.logEnvironmentInfo(LOG, StandaloneSessionClusterEntrypoint.class.getSimpleName(), args);
+        SignalHandler.register(LOG);
+        JvmShutdownSafeguard.installAsShutdownHook(LOG);
+
+        EntrypointClusterConfiguration entrypointClusterConfiguration = null;
+        final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+
+        try {
+            entrypointClusterConfiguration = commandLineParser.parse(args);
+        } catch (Exception e) {
+            LOG.error("Could not parse command line arguments {}.", args, e);
+            commandLineParser.printHelp(MiniClusterEntryPoint.class.getSimpleName());
+            System.exit(1);
+        }
+
+        Configuration configuration = GlobalConfiguration.loadConfiguration(entrypointClusterConfiguration.getConfigDir());
+
+        final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
+                .setConfiguration(configuration)
+                // MiniClusterConfiguration.Builder defaults to 1 TM unless configured manually
+                .setNumTaskManagers(configuration.getInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1))
+                .build();
+
+        MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration);
+
+        try {
+            miniCluster.start();
+        } catch (Exception e) {
+            LOG.error("Failed to start MiniCluster with configuration {}.", miniClusterConfiguration, e);
+            System.exit(1);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1557,6 +1557,9 @@ under the License.
 
 						<!-- AWS SDK config that does not support license headers -->
 						<exclude>**/awssdk/global/handlers/execution.interceptors</exclude>
+
+						<!-- Splunk config for MiniClusterEntryPoint -->
+						<exclude>flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java</exclude>
 					</excludes>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

This is a cherrypick commit for adding MiniClusterEntryPoint. It is an entrypoint main class that is intended to be used to start a single-JVM Flink deployment that runs all necessary cluster components.


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
