### PR TITLE
Handle termination failure

### DIFF
--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
@@ -39,9 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.UndeclaredThrowableException;
 
-/**
- * Entry point for a mini cluster.
- */
+/** Entry point for a mini cluster. */
 public class MiniClusterEntryPoint {
     protected static final Logger LOG = LoggerFactory.getLogger(MiniClusterEntryPoint.class);
 
@@ -51,7 +49,8 @@ public class MiniClusterEntryPoint {
 
     public static void main(String[] args) {
         // startup checks and logging
-        EnvironmentInformation.logEnvironmentInfo(LOG, MiniClusterEntryPoint.class.getSimpleName(), args);
+        EnvironmentInformation.logEnvironmentInfo(
+                LOG, MiniClusterEntryPoint.class.getSimpleName(), args);
         SignalHandler.register(LOG);
         JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
@@ -64,7 +63,8 @@ public class MiniClusterEntryPoint {
         }
 
         EntrypointClusterConfiguration entrypointClusterConfiguration = null;
-        final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+        final CommandLineParser<EntrypointClusterConfiguration> commandLineParser =
+                new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
 
         try {
             entrypointClusterConfiguration = commandLineParser.parse(args);
@@ -74,13 +74,19 @@ public class MiniClusterEntryPoint {
             System.exit(STARTUP_FAILURE_RETURN_CODE);
         }
 
-        Configuration configuration = GlobalConfiguration.loadConfiguration(entrypointClusterConfiguration.getConfigDir());
+        Configuration configuration =
+                GlobalConfiguration.loadConfiguration(
+                        entrypointClusterConfiguration.getConfigDir());
 
-        final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
-                .setConfiguration(configuration)
-                .setNumTaskManagers(configuration.getInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1))
-                .setNumSlotsPerTaskManager(configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1))
-                .build();
+        final MiniClusterConfiguration miniClusterConfiguration =
+                new MiniClusterConfiguration.Builder()
+                        .setConfiguration(configuration)
+                        .setNumTaskManagers(
+                                configuration.getInteger(
+                                        ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1))
+                        .setNumSlotsPerTaskManager(
+                                configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1))
+                        .build();
 
         MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration);
 
@@ -92,27 +98,37 @@ public class MiniClusterEntryPoint {
         }
 
         try {
-            SecurityUtils.getInstalledContext().runSecured(() -> {
-                miniCluster.start();
-                return null;
-            });
+            SecurityUtils.getInstalledContext()
+                    .runSecured(
+                            () -> {
+                                miniCluster.start();
+                                return null;
+                            });
         } catch (Throwable t) {
-            final Throwable strippedThrowable = ExceptionUtils.stripException(t, UndeclaredThrowableException.class);
+            final Throwable strippedThrowable =
+                    ExceptionUtils.stripException(t, UndeclaredThrowableException.class);
             LOG.error("MiniCluster initialization failed.", strippedThrowable);
             System.exit(STARTUP_FAILURE_RETURN_CODE);
         }
 
-        miniCluster.getTerminationFuture().whenComplete((unused, throwable) -> {
-            final int returnCode;
+        miniCluster
+                .getTerminationFuture()
+                .whenComplete(
+                        (unused, throwable) -> {
+                            final int returnCode;
 
-            if (throwable != null) {
-                returnCode = RUNTIME_FAILURE_RETURN_CODE;
-            } else {
-                returnCode = SUCCESS_RETURN_CODE;
-            }
+                            if (throwable != null) {
+                                returnCode = RUNTIME_FAILURE_RETURN_CODE;
+                            } else {
+                                returnCode = SUCCESS_RETURN_CODE;
+                            }
 
-            LOG.info("Terminating cluster entrypoint process {} with exit code {}.", MiniClusterEntryPoint.class.getSimpleName(), returnCode, throwable);
-            System.exit(returnCode);
-        });
+                            LOG.info(
+                                    "Terminating cluster entrypoint process {} with exit code {}.",
+                                    MiniClusterEntryPoint.class.getSimpleName(),
+                                    returnCode,
+                                    throwable);
+                            System.exit(returnCode);
+                        });
     }
 }

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/MiniClusterEntryPoint.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) 2021 Splunk, Inc. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.flink.container.entrypoint;
@@ -7,66 +21,98 @@ package org.apache.flink.container.entrypoint;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.entrypoint.EntrypointClusterConfiguration;
 import org.apache.flink.runtime.entrypoint.EntrypointClusterConfigurationParserFactory;
-import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Entry point for a mini cluster. */
+import java.lang.reflect.UndeclaredThrowableException;
+
+/**
+ * Entry point for a mini cluster.
+ */
 public class MiniClusterEntryPoint {
     protected static final Logger LOG = LoggerFactory.getLogger(MiniClusterEntryPoint.class);
 
+    protected static final int SUCCESS_RETURN_CODE = 0;
+    protected static final int STARTUP_FAILURE_RETURN_CODE = 1;
+    protected static final int RUNTIME_FAILURE_RETURN_CODE = 2;
+
     public static void main(String[] args) {
         // startup checks and logging
-        EnvironmentInformation.logEnvironmentInfo(
-                LOG, StandaloneSessionClusterEntrypoint.class.getSimpleName(), args);
+        EnvironmentInformation.logEnvironmentInfo(LOG, MiniClusterEntryPoint.class.getSimpleName(), args);
         SignalHandler.register(LOG);
         JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
+        long maxOpenFileHandles = EnvironmentInformation.getOpenFileHandlesLimit();
+
+        if (maxOpenFileHandles != -1L) {
+            LOG.info("Maximum number of open file descriptors is {}.", maxOpenFileHandles);
+        } else {
+            LOG.info("Cannot determine the maximum number of open file descriptors");
+        }
+
         EntrypointClusterConfiguration entrypointClusterConfiguration = null;
-        final CommandLineParser<EntrypointClusterConfiguration> commandLineParser =
-                new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
+        final CommandLineParser<EntrypointClusterConfiguration> commandLineParser = new CommandLineParser<>(new EntrypointClusterConfigurationParserFactory());
 
         try {
             entrypointClusterConfiguration = commandLineParser.parse(args);
         } catch (Exception e) {
             LOG.error("Could not parse command line arguments {}.", args, e);
             commandLineParser.printHelp(MiniClusterEntryPoint.class.getSimpleName());
-            System.exit(1);
+            System.exit(STARTUP_FAILURE_RETURN_CODE);
         }
 
-        Configuration configuration =
-                GlobalConfiguration.loadConfiguration(
-                        entrypointClusterConfiguration.getConfigDir());
+        Configuration configuration = GlobalConfiguration.loadConfiguration(entrypointClusterConfiguration.getConfigDir());
 
-        final MiniClusterConfiguration miniClusterConfiguration =
-                new MiniClusterConfiguration.Builder()
-                        .setConfiguration(configuration)
-                        // MiniClusterConfiguration.Builder defaults to 1 TM unless configured
-                        // manually
-                        .setNumTaskManagers(
-                                configuration.getInteger(
-                                        ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1))
-                        .build();
+        final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
+                .setConfiguration(configuration)
+                .setNumTaskManagers(configuration.getInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1))
+                .setNumSlotsPerTaskManager(configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1))
+                .build();
 
         MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration);
 
         try {
-            miniCluster.start();
+            SecurityUtils.install(new SecurityConfiguration(configuration));
         } catch (Exception e) {
-            LOG.error(
-                    "Failed to start MiniCluster with configuration {}.",
-                    miniClusterConfiguration,
-                    e);
-            System.exit(1);
+            LOG.error("Failed to install security configuration.", e);
+            System.exit(STARTUP_FAILURE_RETURN_CODE);
         }
+
+        try {
+            SecurityUtils.getInstalledContext().runSecured(() -> {
+                miniCluster.start();
+                return null;
+            });
+        } catch (Throwable t) {
+            final Throwable strippedThrowable = ExceptionUtils.stripException(t, UndeclaredThrowableException.class);
+            LOG.error("MiniCluster initialization failed.", strippedThrowable);
+            System.exit(STARTUP_FAILURE_RETURN_CODE);
+        }
+
+        miniCluster.getTerminationFuture().whenComplete((unused, throwable) -> {
+            final int returnCode;
+
+            if (throwable != null) {
+                returnCode = RUNTIME_FAILURE_RETURN_CODE;
+            } else {
+                returnCode = SUCCESS_RETURN_CODE;
+            }
+
+            LOG.info("Terminating cluster entrypoint process {} with exit code {}.", MiniClusterEntryPoint.class.getSimpleName(), returnCode, throwable);
+            System.exit(returnCode);
+        });
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -223,6 +223,13 @@ public class MiniCluster implements AutoCloseableAsync {
         this.taskManagers = new ArrayList<>(miniClusterConfiguration.getNumTaskManagers());
     }
 
+    public CompletableFuture<Void> getTerminationFuture() {
+        synchronized (lock) {
+            checkState(running, "MiniCluster is not yet running.");
+            return terminationFuture;
+        }
+    }
+
     public CompletableFuture<URI> getRestAddress() {
         synchronized (lock) {
             checkState(running, "MiniCluster is not yet running or has already been shut down.");


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

cherry-pick for https://cd.splunkdev.com/data-availability/flink/-/commit/29b4f7917a11ee9ce924ef45b22253dd8409cb3c


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
