### PR TITLE
DSP-37971: Add rest handler to submit job with options.

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2677,6 +2677,74 @@
       "type" : "any"
     }
   }, {
+    "url" : "/jobs:submitWithOptions",
+    "method" : "POST",
+    "status-code" : "202 Accepted",
+    "file-upload" : true,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobSubmitRequestWithOptionsBody",
+      "properties" : {
+        "jobGraphFileName" : {
+          "type" : "string"
+        },
+        "jobJarFileNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "jobArtifactFileNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobSubmitRequestBody:DistributedCacheFile",
+            "properties" : {
+              "entryName" : {
+                "type" : "string"
+              },
+              "fileName" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "jobId" : {
+          "type" : "string"
+        },
+        "savepointDirectoryPath" : {
+          "type" : "string"
+        },
+        "allowNonRestoredState" : {
+          "type" : "boolean"
+        },
+        "operatorParallelismChangeMap" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "integer"
+          }
+        },
+        "scaleToSingleTaskManager" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobSubmitResponseBody",
+      "properties" : {
+        "jobUrl" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
     "url" : "/overview",
     "method" : "GET",
     "status-code" : "200 OK",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.job.JobSubmitHandler;
+import org.apache.flink.runtime.rest.handler.job.JobSubmitHandlerWithOptions;
 import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -96,7 +97,15 @@ public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway
                 new JobSubmitHandler(
                         leaderRetriever, timeout, responseHeaders, executor, clusterConfiguration);
 
+        JobSubmitHandlerWithOptions jobSubmitHandlerWithOptions =
+                new JobSubmitHandlerWithOptions(
+                        leaderRetriever, timeout, responseHeaders, executor, clusterConfiguration);
+
         handlers.add(Tuple2.of(jobSubmitHandler.getMessageHeaders(), jobSubmitHandler));
+        handlers.add(
+                Tuple2.of(
+                        jobSubmitHandlerWithOptions.getMessageHeaders(),
+                        jobSubmitHandlerWithOptions));
 
         return handlers;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractJobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/AbstractJobSubmitHandler.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.blob.BlobClient;
+import org.apache.flink.runtime.client.ClientUtils;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.FlinkException;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.ObjectInputStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+/**
+ * This abstract handler class can be used to implement different JobSubmitHandler. Code was
+ * previously part of {@link JobSubmitHandler}.
+ */
+public abstract class AbstractJobSubmitHandler<R extends JobSubmitRequestBody>
+        extends AbstractRestHandler<
+                DispatcherGateway, R, JobSubmitResponseBody, EmptyMessageParameters> {
+
+    protected static final String FILE_TYPE_JOB_GRAPH = "JobGraph";
+    private static final String FILE_TYPE_JAR = "Jar";
+    private static final String FILE_TYPE_ARTIFACT = "Artifact";
+
+    protected final Executor executor;
+    protected final Configuration configuration;
+
+    public AbstractJobSubmitHandler(
+            GatewayRetriever<? extends DispatcherGateway> leaderRetriever,
+            Time timeout,
+            Map<String, String> headers,
+            Executor executor,
+            MessageHeaders<R, JobSubmitResponseBody, EmptyMessageParameters> messageHeaders,
+            Configuration configuration) {
+        super(leaderRetriever, timeout, headers, messageHeaders);
+        this.executor = executor;
+        this.configuration = configuration;
+    }
+
+    @Override
+    protected CompletableFuture<JobSubmitResponseBody> handleRequest(
+            @Nonnull HandlerRequest<R, EmptyMessageParameters> request,
+            @Nonnull DispatcherGateway gateway)
+            throws RestHandlerException {
+        final Collection<File> uploadedFiles = request.getUploadedFiles();
+        final Map<String, Path> nameToFile =
+                uploadedFiles.stream()
+                        .collect(Collectors.toMap(File::getName, Path::fromLocalFile));
+
+        if (uploadedFiles.size() != nameToFile.size()) {
+            throw new RestHandlerException(
+                    String.format(
+                            "The number of uploaded files was %s than the expected count. Expected: %s Actual %s",
+                            uploadedFiles.size() < nameToFile.size() ? "lower" : "higher",
+                            nameToFile.size(),
+                            uploadedFiles.size()),
+                    HttpResponseStatus.BAD_REQUEST);
+        }
+
+        final R requestBody = request.getRequestBody();
+
+        if (requestBody.jobGraphFileName == null) {
+            throw new RestHandlerException(
+                    String.format(
+                            "The %s field must not be omitted or be null.",
+                            JobSubmitRequestBody.FIELD_NAME_JOB_GRAPH),
+                    HttpResponseStatus.BAD_REQUEST);
+        }
+
+        CompletableFuture<JobGraph> jobGraphFuture = loadJobGraph(requestBody, nameToFile);
+
+        CompletableFuture<JobGraph> jobGraphWithOptionsFuture =
+                applyOptionsToJobGraph(jobGraphFuture, requestBody, nameToFile);
+
+        Collection<Path> jarFiles = getJarFilesToUpload(requestBody.jarFileNames, nameToFile);
+
+        Collection<Tuple2<String, Path>> artifacts =
+                getArtifactFilesToUpload(requestBody.artifactFileNames, nameToFile);
+
+        CompletableFuture<JobGraph> finalizedJobGraphFuture =
+                uploadJobGraphFiles(
+                        gateway, jobGraphWithOptionsFuture, jarFiles, artifacts, configuration);
+
+        CompletableFuture<Acknowledge> jobSubmissionFuture =
+                finalizedJobGraphFuture.thenCompose(
+                        jobGraph -> gateway.submitJob(jobGraph, timeout));
+
+        return jobSubmissionFuture.thenCombine(
+                jobGraphWithOptionsFuture,
+                (ack, jobGraph) -> new JobSubmitResponseBody("/jobs/" + jobGraph.getJobID()));
+    }
+
+    protected CompletableFuture<JobGraph> loadJobGraph(R requestBody, Map<String, Path> nameToFile)
+            throws MissingFileException {
+        final Path jobGraphFile =
+                getPathAndAssertUpload(
+                        requestBody.jobGraphFileName, FILE_TYPE_JOB_GRAPH, nameToFile);
+
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    JobGraph jobGraph;
+                    try (ObjectInputStream objectIn =
+                            new ObjectInputStream(
+                                    jobGraphFile.getFileSystem().open(jobGraphFile))) {
+                        jobGraph = (JobGraph) objectIn.readObject();
+                    } catch (Exception e) {
+                        throw new CompletionException(
+                                new RestHandlerException(
+                                        "Failed to deserialize JobGraph.",
+                                        HttpResponseStatus.BAD_REQUEST,
+                                        e));
+                    }
+                    return jobGraph;
+                },
+                executor);
+    }
+
+    protected abstract CompletableFuture<JobGraph> applyOptionsToJobGraph(
+            CompletableFuture<JobGraph> jobGraphFuture,
+            R requestBody,
+            Map<String, Path> nameToFile);
+
+    private static Collection<Path> getJarFilesToUpload(
+            Collection<String> jarFileNames, Map<String, Path> nameToFileMap)
+            throws MissingFileException {
+        Collection<Path> jarFiles = new ArrayList<>(jarFileNames.size());
+        for (String jarFileName : jarFileNames) {
+            Path jarFile = getPathAndAssertUpload(jarFileName, FILE_TYPE_JAR, nameToFileMap);
+            jarFiles.add(new Path(jarFile.toString()));
+        }
+        return jarFiles;
+    }
+
+    private static Collection<Tuple2<String, Path>> getArtifactFilesToUpload(
+            Collection<JobSubmitRequestBody.DistributedCacheFile> artifactEntries,
+            Map<String, Path> nameToFileMap)
+            throws MissingFileException {
+        Collection<Tuple2<String, Path>> artifacts = new ArrayList<>(artifactEntries.size());
+        for (JobSubmitRequestBody.DistributedCacheFile artifactFileName : artifactEntries) {
+            Path artifactFile =
+                    getPathAndAssertUpload(
+                            artifactFileName.fileName, FILE_TYPE_ARTIFACT, nameToFileMap);
+            artifacts.add(Tuple2.of(artifactFileName.entryName, new Path(artifactFile.toString())));
+        }
+        return artifacts;
+    }
+
+    private CompletableFuture<JobGraph> uploadJobGraphFiles(
+            DispatcherGateway gateway,
+            CompletableFuture<JobGraph> jobGraphFuture,
+            Collection<Path> jarFiles,
+            Collection<Tuple2<String, Path>> artifacts,
+            Configuration configuration) {
+        CompletableFuture<Integer> blobServerPortFuture = gateway.getBlobServerPort(timeout);
+
+        return jobGraphFuture.thenCombine(
+                blobServerPortFuture,
+                (JobGraph jobGraph, Integer blobServerPort) -> {
+                    final InetSocketAddress address =
+                            new InetSocketAddress(gateway.getHostname(), blobServerPort);
+                    try {
+                        ClientUtils.uploadJobGraphFiles(
+                                jobGraph,
+                                jarFiles,
+                                artifacts,
+                                () -> new BlobClient(address, configuration));
+                    } catch (FlinkException e) {
+                        throw new CompletionException(
+                                new RestHandlerException(
+                                        "Could not upload job files.",
+                                        HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                        e));
+                    }
+                    return jobGraph;
+                });
+    }
+
+    protected static Path getPathAndAssertUpload(
+            String fileName, String type, Map<String, Path> uploadedFiles)
+            throws MissingFileException {
+        final Path file = uploadedFiles.get(fileName);
+        if (file == null) {
+            throw new MissingFileException(type, fileName);
+        }
+        return file;
+    }
+
+    private static final class MissingFileException extends RestHandlerException {
+
+        private static final long serialVersionUID = -7954810495610194965L;
+
+        MissingFileException(String type, String fileName) {
+            super(
+                    type + " file " + fileName + " could not be found on the server.",
+                    HttpResponseStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
@@ -19,53 +19,20 @@
 package org.apache.flink.runtime.rest.handler.job;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.blob.BlobClient;
-import org.apache.flink.runtime.client.ClientUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
-import org.apache.flink.runtime.rest.handler.HandlerRequest;
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
-import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
-import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
-import org.apache.flink.util.FlinkException;
 
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
-
-import javax.annotation.Nonnull;
-
-import java.io.File;
-import java.io.ObjectInputStream;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
 
 /** This handler can be used to submit jobs to a Flink cluster. */
-public final class JobSubmitHandler
-        extends AbstractRestHandler<
-                DispatcherGateway,
-                JobSubmitRequestBody,
-                JobSubmitResponseBody,
-                EmptyMessageParameters> {
-
-    private static final String FILE_TYPE_JOB_GRAPH = "JobGraph";
-    private static final String FILE_TYPE_JAR = "Jar";
-    private static final String FILE_TYPE_ARTIFACT = "Artifact";
-
-    private final Executor executor;
-    private final Configuration configuration;
+public final class JobSubmitHandler extends AbstractJobSubmitHandler<JobSubmitRequestBody> {
 
     public JobSubmitHandler(
             GatewayRetriever<? extends DispatcherGateway> leaderRetriever,
@@ -73,159 +40,21 @@ public final class JobSubmitHandler
             Map<String, String> headers,
             Executor executor,
             Configuration configuration) {
-        super(leaderRetriever, timeout, headers, JobSubmitHeaders.getInstance());
-        this.executor = executor;
-        this.configuration = configuration;
+        super(
+                leaderRetriever,
+                timeout,
+                headers,
+                executor,
+                JobSubmitHeaders.getInstance(),
+                configuration);
     }
 
+    // No additional options are applied for default JobSubmitHandler
     @Override
-    protected CompletableFuture<JobSubmitResponseBody> handleRequest(
-            @Nonnull HandlerRequest<JobSubmitRequestBody, EmptyMessageParameters> request,
-            @Nonnull DispatcherGateway gateway)
-            throws RestHandlerException {
-        final Collection<File> uploadedFiles = request.getUploadedFiles();
-        final Map<String, Path> nameToFile =
-                uploadedFiles.stream()
-                        .collect(Collectors.toMap(File::getName, Path::fromLocalFile));
-
-        if (uploadedFiles.size() != nameToFile.size()) {
-            throw new RestHandlerException(
-                    String.format(
-                            "The number of uploaded files was %s than the expected count. Expected: %s Actual %s",
-                            uploadedFiles.size() < nameToFile.size() ? "lower" : "higher",
-                            nameToFile.size(),
-                            uploadedFiles.size()),
-                    HttpResponseStatus.BAD_REQUEST);
-        }
-
-        final JobSubmitRequestBody requestBody = request.getRequestBody();
-
-        if (requestBody.jobGraphFileName == null) {
-            throw new RestHandlerException(
-                    String.format(
-                            "The %s field must not be omitted or be null.",
-                            JobSubmitRequestBody.FIELD_NAME_JOB_GRAPH),
-                    HttpResponseStatus.BAD_REQUEST);
-        }
-
-        CompletableFuture<JobGraph> jobGraphFuture = loadJobGraph(requestBody, nameToFile);
-
-        Collection<Path> jarFiles = getJarFilesToUpload(requestBody.jarFileNames, nameToFile);
-
-        Collection<Tuple2<String, Path>> artifacts =
-                getArtifactFilesToUpload(requestBody.artifactFileNames, nameToFile);
-
-        CompletableFuture<JobGraph> finalizedJobGraphFuture =
-                uploadJobGraphFiles(gateway, jobGraphFuture, jarFiles, artifacts, configuration);
-
-        CompletableFuture<Acknowledge> jobSubmissionFuture =
-                finalizedJobGraphFuture.thenCompose(
-                        jobGraph -> gateway.submitJob(jobGraph, timeout));
-
-        return jobSubmissionFuture.thenCombine(
-                jobGraphFuture,
-                (ack, jobGraph) -> new JobSubmitResponseBody("/jobs/" + jobGraph.getJobID()));
-    }
-
-    private CompletableFuture<JobGraph> loadJobGraph(
-            JobSubmitRequestBody requestBody, Map<String, Path> nameToFile)
-            throws MissingFileException {
-        final Path jobGraphFile =
-                getPathAndAssertUpload(
-                        requestBody.jobGraphFileName, FILE_TYPE_JOB_GRAPH, nameToFile);
-
-        return CompletableFuture.supplyAsync(
-                () -> {
-                    JobGraph jobGraph;
-                    try (ObjectInputStream objectIn =
-                            new ObjectInputStream(
-                                    jobGraphFile.getFileSystem().open(jobGraphFile))) {
-                        jobGraph = (JobGraph) objectIn.readObject();
-                    } catch (Exception e) {
-                        throw new CompletionException(
-                                new RestHandlerException(
-                                        "Failed to deserialize JobGraph.",
-                                        HttpResponseStatus.BAD_REQUEST,
-                                        e));
-                    }
-                    return jobGraph;
-                },
-                executor);
-    }
-
-    private static Collection<Path> getJarFilesToUpload(
-            Collection<String> jarFileNames, Map<String, Path> nameToFileMap)
-            throws MissingFileException {
-        Collection<Path> jarFiles = new ArrayList<>(jarFileNames.size());
-        for (String jarFileName : jarFileNames) {
-            Path jarFile = getPathAndAssertUpload(jarFileName, FILE_TYPE_JAR, nameToFileMap);
-            jarFiles.add(new Path(jarFile.toString()));
-        }
-        return jarFiles;
-    }
-
-    private static Collection<Tuple2<String, Path>> getArtifactFilesToUpload(
-            Collection<JobSubmitRequestBody.DistributedCacheFile> artifactEntries,
-            Map<String, Path> nameToFileMap)
-            throws MissingFileException {
-        Collection<Tuple2<String, Path>> artifacts = new ArrayList<>(artifactEntries.size());
-        for (JobSubmitRequestBody.DistributedCacheFile artifactFileName : artifactEntries) {
-            Path artifactFile =
-                    getPathAndAssertUpload(
-                            artifactFileName.fileName, FILE_TYPE_ARTIFACT, nameToFileMap);
-            artifacts.add(Tuple2.of(artifactFileName.entryName, new Path(artifactFile.toString())));
-        }
-        return artifacts;
-    }
-
-    private CompletableFuture<JobGraph> uploadJobGraphFiles(
-            DispatcherGateway gateway,
+    protected CompletableFuture<JobGraph> applyOptionsToJobGraph(
             CompletableFuture<JobGraph> jobGraphFuture,
-            Collection<Path> jarFiles,
-            Collection<Tuple2<String, Path>> artifacts,
-            Configuration configuration) {
-        CompletableFuture<Integer> blobServerPortFuture = gateway.getBlobServerPort(timeout);
-
-        return jobGraphFuture.thenCombine(
-                blobServerPortFuture,
-                (JobGraph jobGraph, Integer blobServerPort) -> {
-                    final InetSocketAddress address =
-                            new InetSocketAddress(gateway.getHostname(), blobServerPort);
-                    try {
-                        ClientUtils.uploadJobGraphFiles(
-                                jobGraph,
-                                jarFiles,
-                                artifacts,
-                                () -> new BlobClient(address, configuration));
-                    } catch (FlinkException e) {
-                        throw new CompletionException(
-                                new RestHandlerException(
-                                        "Could not upload job files.",
-                                        HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                                        e));
-                    }
-                    return jobGraph;
-                });
-    }
-
-    private static Path getPathAndAssertUpload(
-            String fileName, String type, Map<String, Path> uploadedFiles)
-            throws MissingFileException {
-        final Path file = uploadedFiles.get(fileName);
-        if (file == null) {
-            throw new MissingFileException(type, fileName);
-        }
-        return file;
-    }
-
-    private static final class MissingFileException extends RestHandlerException {
-
-        private static final long serialVersionUID = -7954810495610194965L;
-
-        MissingFileException(String type, String fileName) {
-            super(
-                    type + " file " + fileName + " could not be found on the server.",
-                    HttpResponseStatus.BAD_REQUEST);
-        }
+            JobSubmitRequestBody requestBody,
+            Map<String, Path> nameToFile) {
+        return jobGraphFuture;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerWithOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerWithOptions.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestWithOptionsBody;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitWithOptionsHeaders;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+
+/** This handler can be used to submit jobs to a Flink cluster with savepoint settings. */
+public class JobSubmitHandlerWithOptions
+        extends AbstractJobSubmitHandler<JobSubmitRequestWithOptionsBody> {
+
+    public JobSubmitHandlerWithOptions(
+            GatewayRetriever<? extends DispatcherGateway> leaderRetriever,
+            Time timeout,
+            Map<String, String> headers,
+            Executor executor,
+            Configuration configuration) {
+        super(
+                leaderRetriever,
+                timeout,
+                headers,
+                executor,
+                JobSubmitWithOptionsHeaders.getInstance(),
+                configuration);
+    }
+
+    @Override
+    protected CompletableFuture<JobGraph> applyOptionsToJobGraph(
+            CompletableFuture<JobGraph> jobGraphFuture,
+            JobSubmitRequestWithOptionsBody requestBody,
+            Map<String, Path> nameToFile) {
+        return jobGraphFuture.thenApply(
+                jobGraph -> {
+                    setJobId(jobGraph, requestBody.jobId);
+
+                    if (requestBody.savepointDirectoryPath != null) {
+                        setSavepointRestoreSettings(
+                                jobGraph,
+                                requestBody.savepointDirectoryPath,
+                                requestBody.allowNonRestoredState);
+                    }
+
+                    if (requestBody.operatorParallelismChangeMap != null) {
+                        setOperatorParallelisms(jobGraph, requestBody.operatorParallelismChangeMap);
+                    }
+
+                    if (requestBody.scaleToSingleTaskManager) {
+                        scaleOperatorParallelismsToAvailableTaskSlots(jobGraph);
+                    }
+
+                    return jobGraph;
+                });
+    }
+
+    private void setSavepointRestoreSettings(
+            JobGraph jobGraph, String savepointFileName, boolean allowNonRestoredState) {
+        SavepointRestoreSettings savepointRestoreSettings =
+                SavepointRestoreSettings.forPath(savepointFileName, allowNonRestoredState);
+        jobGraph.setSavepointRestoreSettings(savepointRestoreSettings);
+    }
+
+    private void setOperatorParallelisms(
+            JobGraph jobGraph, Map<String, Integer> operatorParallelismChangeMap) {
+        if (jobGraph.getNumberOfVertices() != operatorParallelismChangeMap.size()) {
+            throw new CompletionException(
+                    new RestHandlerException(
+                            "Operator parallelism change map must contain all vertices of corresponding job graph.",
+                            HttpResponseStatus.BAD_REQUEST));
+        }
+
+        jobGraph.getVertices()
+                .forEach(v -> setParallelismForJobVertex(v, operatorParallelismChangeMap));
+    }
+
+    private void setParallelismForJobVertex(
+            JobVertex jobVertex, Map<String, Integer> operatorParallelismChangeMap) {
+        String jobVertexId = jobVertex.getID().toString();
+        if (!operatorParallelismChangeMap.containsKey(jobVertexId)) {
+            throw new CompletionException(
+                    new RestHandlerException(
+                            String.format(
+                                    "Vertex ID %s of job graph not found in provided operator parallelism change map. "
+                                            + "Map must contain all job vertices of job graph.",
+                                    jobVertexId),
+                            HttpResponseStatus.BAD_REQUEST));
+        }
+        jobVertex.setParallelism(operatorParallelismChangeMap.get(jobVertexId));
+    }
+
+    private void scaleOperatorParallelismsToAvailableTaskSlots(JobGraph jobGraph) {
+        jobGraph.getVertices()
+                .forEach(
+                        v ->
+                                v.setParallelism(
+                                        Math.min(
+                                                v.getParallelism(),
+                                                configuration.getInteger(
+                                                        TaskManagerOptions.NUM_TASK_SLOTS))));
+    }
+
+    private static void setJobId(JobGraph jobGraph, String jobID) {
+        jobGraph.setJobID(JobID.fromHexString(jobID));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
@@ -36,11 +36,11 @@ import java.util.Objects;
  * <p>This request only contains the names of files that must be present on the server, and defines
  * how these files are interpreted.
  */
-public final class JobSubmitRequestBody implements RequestBody {
+public class JobSubmitRequestBody implements RequestBody {
 
     public static final String FIELD_NAME_JOB_GRAPH = "jobGraphFileName";
-    private static final String FIELD_NAME_JOB_JARS = "jobJarFileNames";
-    private static final String FIELD_NAME_JOB_ARTIFACTS = "jobArtifactFileNames";
+    protected static final String FIELD_NAME_JOB_JARS = "jobJarFileNames";
+    protected static final String FIELD_NAME_JOB_ARTIFACTS = "jobArtifactFileNames";
 
     @JsonProperty(FIELD_NAME_JOB_GRAPH)
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestWithOptionsBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestWithOptionsBody.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+
+/** Request for submitting a job with options. */
+public class JobSubmitRequestWithOptionsBody extends JobSubmitRequestBody {
+
+    private static final String FIELD_NAME_JOB_ID = "jobId";
+    private static final String FIELD_NAME_SAVEPOINT = "savepointDirectoryPath";
+    private static final String FIELD_NAME_ALLOW_NON_RESTORED_STATE = "allowNonRestoredState";
+    private static final String FIELD_NAME_OPERATOR_PARALLELISM_CHANGE_MAP =
+            "operatorParallelismChangeMap";
+    private static final String FIELD_NAME_SCALE_TO_SINGLE_TASK_MANAGER =
+            "scaleToSingleTaskManager";
+
+    @JsonProperty(FIELD_NAME_JOB_ID)
+    @Nonnull
+    public final String jobId;
+
+    @JsonProperty(FIELD_NAME_SAVEPOINT)
+    @Nullable
+    public final String savepointDirectoryPath;
+
+    @JsonProperty(FIELD_NAME_ALLOW_NON_RESTORED_STATE)
+    public final boolean allowNonRestoredState;
+
+    @JsonProperty(FIELD_NAME_OPERATOR_PARALLELISM_CHANGE_MAP)
+    @Nullable
+    public final Map<String, Integer> operatorParallelismChangeMap;
+
+    @JsonProperty(FIELD_NAME_SCALE_TO_SINGLE_TASK_MANAGER)
+    public final boolean scaleToSingleTaskManager;
+
+    @JsonCreator
+    public JobSubmitRequestWithOptionsBody(
+            @Nullable @JsonProperty(FIELD_NAME_JOB_GRAPH) String jobGraphFileName,
+            @Nullable @JsonProperty(FIELD_NAME_JOB_JARS) Collection<String> jarFileNames,
+            @Nullable @JsonProperty(FIELD_NAME_JOB_ARTIFACTS)
+                    Collection<DistributedCacheFile> artifactFileNames,
+            @Nonnull @JsonProperty(value = FIELD_NAME_JOB_ID, required = true) String jobId,
+            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT) String savepointDirectoryPath,
+            @JsonProperty(FIELD_NAME_ALLOW_NON_RESTORED_STATE) boolean allowNonRestoredState,
+            @Nullable @JsonProperty(FIELD_NAME_OPERATOR_PARALLELISM_CHANGE_MAP)
+                    Map<String, Integer> operatorParallelismChangeMap,
+            @JsonProperty(FIELD_NAME_SCALE_TO_SINGLE_TASK_MANAGER)
+                    boolean scaleToSingleTaskManager) {
+        super(jobGraphFileName, jarFileNames, artifactFileNames);
+        this.jobId = jobId;
+        this.savepointDirectoryPath = savepointDirectoryPath;
+        this.allowNonRestoredState = allowNonRestoredState;
+        this.operatorParallelismChangeMap = operatorParallelismChangeMap;
+        this.scaleToSingleTaskManager = scaleToSingleTaskManager;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JobSubmitRequestWithOptionsBody that = (JobSubmitRequestWithOptionsBody) o;
+        return Objects.equals(jobGraphFileName, that.jobGraphFileName)
+                && Objects.equals(jarFileNames, that.jarFileNames)
+                && Objects.equals(artifactFileNames, that.artifactFileNames)
+                && Objects.equals(jobId, that.jobId)
+                && Objects.equals(savepointDirectoryPath, that.savepointDirectoryPath)
+                && allowNonRestoredState == that.allowNonRestoredState
+                && Objects.equals(operatorParallelismChangeMap, that.operatorParallelismChangeMap)
+                && scaleToSingleTaskManager == that.scaleToSingleTaskManager;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                jobGraphFileName,
+                jarFileNames,
+                artifactFileNames,
+                jobId,
+                savepointDirectoryPath,
+                allowNonRestoredState,
+                operatorParallelismChangeMap,
+                scaleToSingleTaskManager);
+    }
+
+    @Override
+    public String toString() {
+        return "JobSubmitRequestWithOptionsBody{"
+                + "jobGraphFileName='"
+                + jobGraphFileName
+                + '\''
+                + ", jarFileNames="
+                + jarFileNames
+                + ", artifactFileNames="
+                + artifactFileNames
+                + ", jobId='"
+                + jobId
+                + '\''
+                + ", savepointDirectoryPath'="
+                + savepointDirectoryPath
+                + '\''
+                + ", allowNonRestoredState="
+                + allowNonRestoredState
+                + ", operatorParallelismChangeMap="
+                + operatorParallelismChangeMap
+                + ", scaleToSingleTaskManager="
+                + scaleToSingleTaskManager
+                + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitWithOptionsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitWithOptionsHeaders.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.FileUploadHandler;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * These headers define the protocol for submitting a job to a flink cluster with additional
+ * options.
+ */
+public class JobSubmitWithOptionsHeaders
+        implements MessageHeaders<
+                JobSubmitRequestWithOptionsBody, JobSubmitResponseBody, EmptyMessageParameters> {
+    private static final String URL = "/jobs:submitWithOptions";
+    private static final JobSubmitWithOptionsHeaders INSTANCE = new JobSubmitWithOptionsHeaders();
+
+    private JobSubmitWithOptionsHeaders() {}
+
+    @Override
+    public Class<JobSubmitRequestWithOptionsBody> getRequestClass() {
+        return JobSubmitRequestWithOptionsBody.class;
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.POST;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public Class<JobSubmitResponseBody> getResponseClass() {
+        return JobSubmitResponseBody.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.ACCEPTED;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    public static JobSubmitWithOptionsHeaders getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Submits a job with options provided. This call is primarily intended to be used by the Flink client. This call expects a "
+                + "multipart/form-data request that consists of file uploads for the serialized JobGraph, jars, "
+                + "distributed cache artifacts, savepoints and an attribute named \""
+                + FileUploadHandler.HTTP_ATTRIBUTE_REQUEST
+                + "\" for "
+                + "the JSON payload.";
+    }
+
+    @Override
+    public boolean acceptsFileUploads() {
+        return true;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerWithOptionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerWithOptionsTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.net.SSLUtilsTest;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestWithOptionsBody;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Tests for the {@link JobSubmitHandlerWithOptions}. */
+@RunWith(Parameterized.class)
+public class JobSubmitHandlerWithOptionsTest {
+    @Parameterized.Parameters(name = "SSL enabled: {0}")
+    public static Iterable<Tuple2<Boolean, String>> data() {
+        ArrayList<Tuple2<Boolean, String>> parameters = new ArrayList<>(3);
+        parameters.add(Tuple2.of(false, "no SSL"));
+        for (String sslProvider : SSLUtilsTest.AVAILABLE_SSL_PROVIDERS) {
+            parameters.add(Tuple2.of(true, sslProvider));
+        }
+        return parameters;
+    }
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    private final Configuration configuration;
+
+    private BlobServer blobServer;
+
+    public JobSubmitHandlerWithOptionsTest(Tuple2<Boolean, String> withSsl) {
+        this.configuration =
+                withSsl.f0
+                        ? SSLUtilsTest.createInternalSslConfigWithKeyAndTrustStores(withSsl.f1)
+                        : new Configuration();
+    }
+
+    @Before
+    public void setup() throws IOException {
+        Configuration config = new Configuration(configuration);
+        config.setString(
+                BlobServerOptions.STORAGE_DIRECTORY,
+                TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+
+        blobServer = new BlobServer(config, new VoidBlobStore());
+        blobServer.start();
+    }
+
+    @After
+    public void teardown() throws IOException {
+        if (blobServer != null) {
+            blobServer.close();
+        }
+    }
+
+    @Test
+    public void testSuccesfulJobSubmissionWithSavepointOptionsSet() throws Exception {
+        // Given
+        final String testSavepointPath = "testSavepointPath";
+        final boolean testAllowNonRestoredState = true;
+        final boolean scaleToSingleTaskManager = false;
+        final String initialTestJobID = "00000000000000000000000000000000";
+        final String changedTestJobID = "11111111111111111111111111111111";
+        final Map<String, Integer> testVertexIdParallelismMap =
+                Stream.of(
+                                new String[][] {
+                                    {"22222222222222222222222222222222", "2"},
+                                    {"33333333333333333333333333333333", "3"},
+                                })
+                        .collect(
+                                Collectors.toMap(
+                                        data -> data[0], data -> Integer.valueOf(data[1])));
+        final Path jobGraphFile = TEMPORARY_FOLDER.newFile().toPath();
+
+        try (ObjectOutputStream objectOut =
+                new ObjectOutputStream(Files.newOutputStream(jobGraphFile))) {
+            JobGraph jobGraph = new JobGraph(JobID.fromHexString(initialTestJobID), "testJob");
+            testVertexIdParallelismMap.forEach(
+                    ((k, v) -> {
+                        JobVertex jobVertex = new JobVertex(k, JobVertexID.fromHexString(k));
+                        jobVertex.setParallelism(v);
+                        jobGraph.addVertex(jobVertex);
+                    }));
+            objectOut.writeObject(jobGraph);
+        }
+
+        CompletableFuture<JobGraph> submittedJobGraphFuture = new CompletableFuture<>();
+        DispatcherGateway dispatcherGateway =
+                new TestingDispatcherGateway.Builder()
+                        .setBlobServerPort(blobServer.getPort())
+                        .setSubmitFunction(
+                                submittedJobGraph -> {
+                                    submittedJobGraphFuture.complete(submittedJobGraph);
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                })
+                        .build();
+
+        JobSubmitHandlerWithOptions handler =
+                new JobSubmitHandlerWithOptions(
+                        () -> CompletableFuture.completedFuture(dispatcherGateway),
+                        RpcUtils.INF_TIMEOUT,
+                        Collections.emptyMap(),
+                        TestingUtils.defaultExecutor(),
+                        configuration);
+
+        JobSubmitRequestWithOptionsBody request =
+                new JobSubmitRequestWithOptionsBody(
+                        jobGraphFile.getFileName().toString(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        changedTestJobID,
+                        testSavepointPath,
+                        testAllowNonRestoredState,
+                        testVertexIdParallelismMap,
+                        scaleToSingleTaskManager);
+
+        // When
+        handler.handleRequest(
+                        new HandlerRequest<>(
+                                request,
+                                EmptyMessageParameters.getInstance(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                Collections.singletonList(jobGraphFile.toFile())),
+                        dispatcherGateway)
+                .get();
+
+        // Then
+        Assert.assertTrue("No JobGraph was submitted.", submittedJobGraphFuture.isDone());
+        final JobGraph submittedJobGraph = submittedJobGraphFuture.get();
+        Assert.assertEquals(
+                testAllowNonRestoredState,
+                submittedJobGraph.getSavepointRestoreSettings().allowNonRestoredState());
+        Assert.assertEquals(
+                testSavepointPath,
+                submittedJobGraph.getSavepointRestoreSettings().getRestorePath());
+        Assert.assertEquals(changedTestJobID, submittedJobGraph.getJobID().toString());
+        testVertexIdParallelismMap.forEach(
+                (k, v) ->
+                        Assert.assertEquals(
+                                submittedJobGraph
+                                        .findVertexByID(JobVertexID.fromHexString(k))
+                                        .getParallelism(),
+                                v.intValue()));
+    }
+}


### PR DESCRIPTION
DSP-37971: Add max parallelism to API to remove job graph dependency.

This PR adds an additional Rest API handler class that enables job submission with additional options that can be set on the jobgraph.

In this PR we make the following options available:

* Load a job from a savepoint.
* Set the parallelism of individual operators.
* Cap the operator parallelism to the number of available task slots.

Since the new JobSubmitHandlerWithOptions shares most of its functionality with the existing JobSubmitHandler but requires it's own request class, we added an AbstractJobSubmitHandler class from which both job submit handler inherit. The new handler can be extended to support additional options in the future.